### PR TITLE
Fix for global query

### DIFF
--- a/_backend/services/quote-service/src/main/java/com/quotes/MongoUtil.java
+++ b/_backend/services/quote-service/src/main/java/com/quotes/MongoUtil.java
@@ -116,24 +116,37 @@ public class MongoUtil {
     }
 
     public String searchQuote(String searchQuery, boolean filterUsed, boolean filterBookmarked, boolean filterUploaded,
-                              String IncludeTerms, String ExcludeTerms, String jwtString) { // fuzzy search for quote
+                              String IncludeTerms, String ExcludeTerms, String jwtString, boolean isGuest) { // fuzzy search for quote
+
         MongoCollection<Document> collection = database.getCollection("Quotes");
+
+        //certain filter fields only available to user
         List<String> filterQuoteIds = new ArrayList<>(); //instantiate list of quote id's to compare to
-        Document userDoc = retrieveUserFromJWT(jwtString); //Get User Document
-        if(filterUsed) { //if filter used, add quote ids to filterlist
+        Document userDoc = new Document();
+        String userId = null;
+        if(!isGuest) {
+            userDoc = retrieveUserFromJWT(jwtString); //Get User Document if not guest
+            if(userDoc == null) {
+                return null;
+            }
+            userId = userDoc.getObjectId("_id").toHexString();
+        }
+
+        if(filterUsed && !isGuest) { //if filter true, add quote ids to filter list
             filterQuoteIds.addAll(fetchUserUsedQuoteIds(userDoc)); // append list containing used quote id's
         }
-        if(filterBookmarked) {
+        if(filterBookmarked && !isGuest) {
             filterQuoteIds.addAll(fetchUserBookmarkedQuotes(userDoc));
         }
-        if(filterUploaded) {
+        if(filterUploaded && !isGuest) {
             filterQuoteIds.addAll(fetchUserUploadedQuotes(userDoc));
         }
 
+        //following fields will still work for guest
         List<String> TermsToInclude = new ArrayList<>();
         List<Document> ShouldClause = new ArrayList<>();
         if(IncludeTerms != null) {
-            TermsToInclude = Arrays.stream(IncludeTerms.split(",")).toList(); //split "," separated terms into list
+            TermsToInclude = Arrays.stream(IncludeTerms.split(",")).toList(); //split terms into list
             //create clause specifying quote must should include specified terms
             ShouldClause.add(new Document("text", new Document("query", TermsToInclude).append("path", "quote")));
         }
@@ -146,6 +159,7 @@ public class MongoUtil {
             MustNotClause.add(new Document("text", new Document("query", TermsToExclude).append("path", "quote")));
         }
 
+        //Base clause
         List<Document> MustClause = List.of( //search that "must" occur
                 new Document("text", new Document("query", searchQuery) //set query string to user query
                         .append("path", Arrays.asList("quote", "author", "tags")) // fields to search and compare to
@@ -157,22 +171,38 @@ public class MongoUtil {
         Document CompoundDoc = new Document("must", MustClause); //default searching
         //append include/exclude clauses if specified
         if(!TermsToInclude.isEmpty()) {
-            CompoundDoc.append("should", ShouldClause).append("minimumShouldMatch", 1); //Num of elements the quote text must include
+            CompoundDoc.append("should", ShouldClause).append("minimumShouldMatch", 1); //Min num of elements the quote text must include
         }
         if(!TermsToExclude.isEmpty()) {
             CompoundDoc.append("mustNot", MustNotClause);
         }
 
         // create query document
-        AggregateIterable<Document> results = collection.aggregate(Arrays.asList(
-                new Document("$search", new Document("index", "QuotesAtlasSearch") //set to search atlas index
-                        .append("compound", CompoundDoc)),
-                //post search section
-                new Document("$match", new Document("private", new Document("$ne", true))), //Exclude private quotes
-                new Document("$match", new Document("_id.oid", new Document("$nin", filterQuoteIds))), //Ignore specified quotes
-                new Document("$sort", new Document("score", -1)), //sort by relevance
-                new Document("$limit", 50) //limit to 50 results
-        ));
+        AggregateIterable<Document> results;
+        if(isGuest) { //query if is guest
+            results = collection.aggregate(Arrays.asList(
+                    new Document("$search", new Document("index", "QuotesAtlasSearch") //set to search atlas index
+                            .append("compound", CompoundDoc)),
+                    //post search section
+                    new Document("$match", new Document("private", new Document("$ne", true))), //Exclude private quotes
+                    new Document("$match", new Document("_id.oid", new Document("$nin", filterQuoteIds))), //Ignore specified quotes
+                    new Document("$sort", new Document("score", -1)), //sort by relevance
+                    new Document("$limit", 50) //limit to 50 results
+            ));
+        } else { //query if is user
+            results = collection.aggregate(Arrays.asList(
+                    new Document("$search", new Document("index", "QuotesAtlasSearch") //set to search atlas index
+                            .append("compound", CompoundDoc)),
+                    //post search section
+                    new Document("$match", new Document("$or", List.of(
+                            new Document("private", new Document("$ne", true)), //exclude private quotes
+                            new Document("$expr", new Document("$eq", List.of("$creator", userId))) //unless is creator
+                    ))),
+                    new Document("$match", new Document("_id.oid", new Document("$nin", filterQuoteIds))), //Ignore specified quotes
+                    new Document("$sort", new Document("score", -1)), //sort by relevance
+                    new Document("$limit", 50) //limit to 50 results
+            ));
+        }
 
         JsonArrayBuilder jsonArrayBuilder = Json.createArrayBuilder();
 

--- a/_backend/services/quote-service/src/main/java/com/quotes/MongoUtil.java
+++ b/_backend/services/quote-service/src/main/java/com/quotes/MongoUtil.java
@@ -154,7 +154,7 @@ public class MongoUtil {
         List<String> TermsToExclude = new ArrayList<>();
         List<Document> MustNotClause = new ArrayList<>();
         if(ExcludeTerms != null) {
-            TermsToExclude = Arrays.stream(ExcludeTerms.split(",")).toList(); //split "," separated terms into list
+            TermsToExclude = Arrays.stream(ExcludeTerms.split(",")).toList(); //split terms into list
             //create clause specifying quote must not include specified terms
             MustNotClause.add(new Document("text", new Document("query", TermsToExclude).append("path", "quote")));
         }

--- a/_backend/services/quote-service/src/main/java/com/quotes/QuoteSearchResource.java
+++ b/_backend/services/quote-service/src/main/java/com/quotes/QuoteSearchResource.java
@@ -88,14 +88,18 @@ public class QuoteSearchResource {
             //get user jwt from header
             boolean isGuest;
             String authHeader = header.getHeaderString(HttpHeaders.AUTHORIZATION);
-            if (authHeader == null || !authHeader.toLowerCase().startsWith("bearer ")) {
-                //return Response.status(Response.Status.UNAUTHORIZED)
-                //        .entity(new Document("error", "Missing or invalid Authorization header").toJson())
-                //        .build();
+            if (authHeader == null) {
+                //no jwt, treat as guest
                 isGuest = true;
+            } else if(!authHeader.toLowerCase().startsWith("bearer ")) {
+                return Response.status(Response.Status.UNAUTHORIZED)
+                        .entity(new Document("error", "Missing or invalid Authorization header").toJson())
+                        .build();
             } else {
+                //valid jwt, treat as user
                 isGuest = false;
             }
+
             String jwtString = authHeader.replaceFirst("(?i)^Bearer\\s+", "");
 
             //handle query string

--- a/_backend/services/quote-service/src/main/java/com/quotes/QuoteSearchResource.java
+++ b/_backend/services/quote-service/src/main/java/com/quotes/QuoteSearchResource.java
@@ -67,17 +67,34 @@ public class QuoteSearchResource {
     })
     @Operation(summary = "Fuzzy search for quotes relevant to supplied query",
     description = "Searches for quotes similar to the users input and returns json of quotes determined to be most similar." +
-            " They are sorted in descending order so the first json object is the closest to users input")
-    public Response advancedSearch(@QueryParam("filterUsed") boolean filterUsed, @QueryParam("filterBookmarked") boolean filterBookmarked,
-                                   @QueryParam("filterUploaded") boolean filterUploaded, @QueryParam("include") String Included,
-                                   @QueryParam("exclude") String Excluded, @QueryParam("query") String query, @Context HttpHeaders header) {
+            " They are sorted in descending order so the first json object is the closest to users input.")
+    public Response advancedSearch(@QueryParam("filterUsed") @Parameter(description = "Should filter out Used Quotes. Defaults to false if left blank", required = false)
+                                       boolean filterUsed,
+                                   @QueryParam("filterBookmarked") @Parameter(description = "Should filter out Bookmarked Quotes. Defaults to false if left blank", required = false)
+                                   boolean filterBookmarked,
+                                   @QueryParam("filterUploaded") @Parameter(description = "Should filter out users Uploaded Quotes. Defaults to false if left blank", required = false)
+                                       boolean filterUploaded,
+                                   @QueryParam("include") @Parameter(description = "String of terms that must be included in quote. Leave as comma separated string. null if left blank",
+                                           required = false, example = "one,two,three")
+                                       String Included,
+                                   @QueryParam("exclude") @Parameter(description = "String of terms that must be excluded in quote. Leave as comma separated string. null if left blank",
+                                           required = false, example = "one,two,three")
+                                       String Excluded,
+                                   @QueryParam("query") @Parameter(description = "Query string user entered", required = true)
+                                       String query,
+                                   @Context HttpHeaders header)
+    {
         try{
             //get user jwt from header
+            boolean isGuest;
             String authHeader = header.getHeaderString(HttpHeaders.AUTHORIZATION);
             if (authHeader == null || !authHeader.toLowerCase().startsWith("bearer ")) {
-                return Response.status(Response.Status.UNAUTHORIZED)
-                        .entity(new Document("error", "Missing or invalid Authorization header").toJson())
-                        .build();
+                //return Response.status(Response.Status.UNAUTHORIZED)
+                //        .entity(new Document("error", "Missing or invalid Authorization header").toJson())
+                //        .build();
+                isGuest = true;
+            } else {
+                isGuest = false;
             }
             String jwtString = authHeader.replaceFirst("(?i)^Bearer\\s+", "");
 
@@ -87,7 +104,10 @@ public class QuoteSearchResource {
             }
             query = SanitizerClass.sanitize(query); //removes special characters
             //search database using Atlas Search
-            String result = mongo.searchQuote(query, filterUsed, filterBookmarked, filterUploaded, Included, Excluded, jwtString);
+            String result = mongo.searchQuote(query, filterUsed, filterBookmarked, filterUploaded, Included, Excluded, jwtString, isGuest);
+            if(result == null) {
+                return Response.status(Response.Status.EXPECTATION_FAILED).entity("Error getting user info").build();
+            }
             return Response.ok(result).build();
         } catch (Exception e) {
             return Response.status(Response.Status.CONFLICT).entity("Exception Occured: "+e).build();


### PR DESCRIPTION
Changed to allow for guests to still use endpoint. If request is made with no jwt/auth, the request will be treated as a guest request with limited filter functionality. If the request has a jwt then it will allow for more filter options.