### PR TITLE
Profanity Filter

### DIFF
--- a/_backend/services/quote-service/src/main/java/com/moderation/ProfanityClass.java
+++ b/_backend/services/quote-service/src/main/java/com/moderation/ProfanityClass.java
@@ -1,0 +1,46 @@
+package com.moderation;
+
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+public class ProfanityClass {
+
+    private final HttpClient client = HttpClient.newHttpClient();
+    private static final URI PROFANITY_API = URI.create("https://vector.profanity.dev");
+
+    public boolean checkProfanity(String message) {
+        try {
+            // Build the JSON body
+            String jsonBody = "{\"message\":\"" + message.replace("\"", "\\\"") + "\"}";
+
+            // Fire the HTTP request
+            HttpRequest request = HttpRequest.newBuilder(PROFANITY_API)
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            String body = response.body();
+
+            // Parse the JSON response
+            try (JsonReader jr = Json.createReader(new StringReader(body))) {
+                JsonObject json = jr.readObject();
+                // if the API ever changes the field name, supply a default of false:
+                return json.getBoolean("isProfanity", false);
+            }
+
+        } catch (Exception e) {
+
+            e.printStackTrace();
+            // fallback if anything goes wrong:
+            return false;
+        }
+    }
+}

--- a/_backend/services/quote-service/src/main/java/com/quotes/QuotesUpdateResource.java
+++ b/_backend/services/quote-service/src/main/java/com/quotes/QuotesUpdateResource.java
@@ -1,6 +1,7 @@
 package com.quotes;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jakarta.inject.Inject;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -10,6 +11,7 @@ import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.*;
+
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.eclipse.microprofile.openapi.annotations.Operation;
@@ -24,11 +26,16 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
+import com.moderation.ProfanityClass;
+
 @Path("/update")
 public class QuotesUpdateResource {
 
     @Inject
     MongoUtil mongo;
+
+    @Inject
+    ProfanityClass profanityFilter;
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
@@ -100,6 +107,15 @@ public class QuotesUpdateResource {
                 return Response.status(Response.Status.CONFLICT).entity("Error when sanitizing quote, returned null").build();
             }
 
+
+                if(profanityFilter.checkProfanity(quote.getText())) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity("Quote content is inappropiate").build();
+                }
+                if(profanityFilter.checkProfanity(quote.getAuthor())) {
+                    return Response.status(Response.Status.BAD_REQUEST).entity("Author content is inappropiate").build();
+                }
+
+         
             boolean updated = mongo.updateQuote(quote);
 
             if(updated) {

--- a/_backend/services/user-service/src/main/java/com/accounts/AccountsResource.java
+++ b/_backend/services/user-service/src/main/java/com/accounts/AccountsResource.java
@@ -2,8 +2,12 @@ package com.accounts;
 
 import com.auth.Session;
 import com.auth.SessionService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.client.model.Updates;
+
 import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
 import jakarta.json.Json;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.servlet.http.Cookie;
@@ -29,11 +33,17 @@ import com.ibm.websphere.security.jwt.JwtToken;
 import java.security.Principal;
 import java.util.Arrays;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moderation.ProfanityClass;
+
 @Path("/accounts")
 public class AccountsResource {
 
     public static AccountService accountService = new AccountService();
     public static SessionService sessionService = new SessionService();
+
+    @Inject
+    ProfanityClass profanityFilter;
 
     @POST
     @Path("/create")
@@ -54,6 +64,8 @@ public class AccountsResource {
             + "\"SharedQuotes\": [\"Success is a journey\"], "
             + "\"MyTags\": [\"Inspiration\", \"Wisdom\"], " + "\"Profession\": \"NFL Head Coach\"," + "\"PersonalQuote\": \"67abf469b0d20a5237456444\"" + "}")))
     public Response create(String json) {
+
+   
         return accountService.newUser(json);
     }
 

--- a/_backend/services/user-service/src/main/java/com/accounts/AccountsResource.java
+++ b/_backend/services/user-service/src/main/java/com/accounts/AccountsResource.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.client.model.Updates;
 
 import jakarta.annotation.security.RolesAllowed;
-import jakarta.inject.Inject;
 import jakarta.json.Json;
 import jakarta.json.JsonObjectBuilder;
 import jakarta.servlet.http.Cookie;
@@ -34,7 +33,6 @@ import java.security.Principal;
 import java.util.Arrays;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.moderation.ProfanityClass;
 
 @Path("/accounts")
 public class AccountsResource {
@@ -42,8 +40,6 @@ public class AccountsResource {
     public static AccountService accountService = new AccountService();
     public static SessionService sessionService = new SessionService();
 
-    @Inject
-    ProfanityClass profanityFilter;
 
     @POST
     @Path("/create")
@@ -64,8 +60,6 @@ public class AccountsResource {
             + "\"SharedQuotes\": [\"Success is a journey\"], "
             + "\"MyTags\": [\"Inspiration\", \"Wisdom\"], " + "\"Profession\": \"NFL Head Coach\"," + "\"PersonalQuote\": \"67abf469b0d20a5237456444\"" + "}")))
     public Response create(String json) {
-
-   
         return accountService.newUser(json);
     }
 

--- a/_backend/services/user-service/src/main/java/com/moderation/ProfanityClass.java
+++ b/_backend/services/user-service/src/main/java/com/moderation/ProfanityClass.java
@@ -1,0 +1,46 @@
+package com.moderation;
+
+import java.io.StringReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+public class ProfanityClass {
+
+    private final HttpClient client = HttpClient.newHttpClient();
+    private static final URI PROFANITY_API = URI.create("https://vector.profanity.dev");
+
+    public boolean checkProfanity(String message) {
+        try {
+            // Build the JSON body
+            String jsonBody = "{\"message\":\"" + message.replace("\"", "\\\"") + "\"}";
+
+            // Fire the HTTP request
+            HttpRequest request = HttpRequest.newBuilder(PROFANITY_API)
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            String body = response.body();
+
+            // Parse the JSON response
+            try (JsonReader jr = Json.createReader(new StringReader(body))) {
+                JsonObject json = jr.readObject();
+                // if the API ever changes the field name, supply a default of false:
+                return json.getBoolean("isProfanity", false);
+            }
+
+        } catch (Exception e) {
+
+            e.printStackTrace();
+            // fallback if anything goes wrong:
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Implemented a basic profanity check for creating/updating quotes - including the quote text and author field.

Additionally, a profanity check for updating/creating a users "Personal Quote" and "Profession". 

for some reason this isn't working correctly with these fields, not sure if it's a frontend or backend problem as the implementation is almost identical to how I did it with quotes. Current implentation uses an external API, which provides a thorough profanity check but obviously issues occur if the service were to ever go down, so for now let's assume that won't happen anytime soon.