### PR TITLE
Inter service calls made safer

### DIFF
--- a/_backend/services/quote-service/src/main/java/com/quotes/MongoUtil.java
+++ b/_backend/services/quote-service/src/main/java/com/quotes/MongoUtil.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.StringWriter;
 import java.util.*;
 
+import javax.print.Doc;
+
 import static com.mongodb.client.model.Filters.eq;
 
 @ApplicationScoped
@@ -331,9 +333,43 @@ public class MongoUtil {
         }
     }
 
+    public boolean incrementBookmarkCount(ObjectId quoteId) {
+        MongoCollection<Document> collection = database.getCollection("Quotes");
+        try{
+            Document IdQuery = new Document("_id",quoteId);
+            Document updateOperation = new Document("$inc",new Document("bookmarks",1));
+            long modifiedCount = collection.updateOne(IdQuery, updateOperation).getModifiedCount();
+            return modifiedCount > 0;
+        }
+        catch(Exception e){
+            e.printStackTrace();
+            return false;
+        }
+       
+        
+    }
+
+    public boolean decrementBookmarkCount(ObjectId quoteId) {
+        MongoCollection<Document> collection = database.getCollection("Quotes");
+        try{
+            Document IdQuery = new Document("_id",quoteId);
+            Document updateOperation = new Document("$inc",new Document("bookmarks",-1));
+            long modifiedCount = collection.updateOne(IdQuery, updateOperation).getModifiedCount();
+            return modifiedCount > 0;
+        }
+        catch(Exception e){
+            e.printStackTrace();
+            return false;
+        }
+       
+        
+    }
+
+
     public boolean deleteQuote(ObjectId quoteId) {
         MongoCollection<Document> collection = database.getCollection("Quotes");
         try {
+
             //create query document with id
             Document idQuery = new Document();
             idQuery.append("_id", quoteId);

--- a/_backend/services/quote-service/src/main/java/com/quotes/QuoteCreateResource.java
+++ b/_backend/services/quote-service/src/main/java/com/quotes/QuoteCreateResource.java
@@ -114,7 +114,7 @@ public class QuoteCreateResource {
                 List<String> MyQuotes = accDoc.getList("MyQuotes", String.class);
                 MyQuotes.add(newQuoteId.toString());
                 accDoc.put("MyQuotes",MyQuotes);
-                Response updateUser = userClient.updateMyQuotes(accountID,accDoc.toJson());
+                Response updateUser = userClient.insertIntoMyQuotes(accountID,newQuoteId.toString(),authHeader);
                 
             }
             

--- a/_backend/services/quote-service/src/main/java/com/quotes/QuoteDeleteResource.java
+++ b/_backend/services/quote-service/src/main/java/com/quotes/QuoteDeleteResource.java
@@ -126,15 +126,7 @@ public class QuoteDeleteResource {
             }
             boolean result = mongo.deleteQuote(objectId);
             if(result) {
-                Response findAccount = userClient.search(accountID);
-            if (findAccount.getStatus() == Response.Status.OK.getStatusCode()) {
-                String accSearchString = findAccount.readEntity(String.class);
-                Document accDoc = Document.parse(accSearchString);
-                List<String> MyQuotes = accDoc.getList("MyQuotes", String.class);
-                MyQuotes.remove(quoteID);
-                accDoc.put("MyQuotes",MyQuotes);
-                Response updateUser = userClient.updateMyQuotes(accountID,accDoc.toJson());   
-            }
+                Response updateUser = userClient.deleteFromMyQuotes(accountID,quoteID,authHeader);   
                 JsonObject jsonResponse = Json.createObjectBuilder()
                         .add("Response", "200")
                         .build();

--- a/_backend/services/quote-service/src/main/java/com/quotes/UserClient.java
+++ b/_backend/services/quote-service/src/main/java/com/quotes/UserClient.java
@@ -11,10 +11,15 @@ import jakarta.ws.rs.core.Response;
 @RegisterRestClient(baseUri = "http://user-service:9081")
 public interface UserClient{
    
-    @PUT
-    @Path("/users/accounts/update/MyQuotes/{id}")
+    @DELETE
+    @Path("/users/accounts/delete/MyQuotes/{userId}/{quoteId}")
     @Consumes(MediaType.APPLICATION_JSON)
-    Response updateMyQuotes(@PathParam("id") String id, String accountJson);
+    Response deleteFromMyQuotes(@PathParam("userId") String id, @PathParam("quoteId") String quoteId,@HeaderParam("Authorization") String authHeader);
+
+    @PUT
+    @Path("/users/accounts/insert/MyQuotes/{userId}/{quoteId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response insertIntoMyQuotes(@PathParam("userId") String id, @PathParam("quoteId") String quoteId,@HeaderParam("Authorization") String authHeader);
 
     @GET
     @Path("/users/accounts/search/{id}")

--- a/_backend/services/user-service/src/main/java/com/accounts/AccountService.java
+++ b/_backend/services/user-service/src/main/java/com/accounts/AccountService.java
@@ -490,4 +490,98 @@ public class AccountService {
 
         return doc.getObjectId("_id").toHexString();
     }
+
+    public Response deleteFromUsersMyQuotes(String userId,String quoteId) {
+        ObjectId objectId;
+
+        try {
+            objectId = new ObjectId(userId);
+        } catch (Exception e) {
+            return Response
+                    .status(Response.Status.NOT_FOUND)
+                    .entity(new Document("error", "Invalid object id!").toJson())
+                    .build();
+        }
+        Response res = retrieveUser(userId, false);
+        String entity = res.readEntity(String.class);
+        Document updatedAccountDocument = Document.parse(entity);
+        updatedAccountDocument.getList("MyQuotes",String.class).remove(quoteId);
+        UpdateResult updateResult = accountCollection.updateOne(
+                eq("_id", objectId),
+                new Document("$set", updatedAccountDocument)
+        );
+
+        if (updateResult.getModifiedCount() == 1) {
+            try {
+                ArrayList<String> fieldsList = new ArrayList<String>(
+                        List.of("Email", "Username", "admin", "Notifications", "MyQuotes",
+                                "BookmarkedQuotes", "SharedQuotes", "MyTags", "Profession", "PersonalQuote","UsedQuotes"));
+
+                Bson projectionFields = Projections.fields(
+                        Projections.include(fieldsList));
+
+                return Response
+                        .status(Response.Status.OK)
+                        .entity(accountCollection.find(eq("_id", objectId)).projection(projectionFields).first().toJson())
+                        .build();
+            } catch (NullPointerException e) {
+                return Response
+                        .status(Response.Status.NOT_FOUND)
+                        .entity(new Document("error", "Account Not found!").toJson())
+                        .build();
+            }
+        } else {
+            return Response
+                    .status(Response.Status.NOT_FOUND)
+                    .entity(new Document("error", "Account Not found!").toJson())
+                    .build();
+        }
+    }
+
+    public Response insertIntoUsersMyQuotes(String userId,String quoteId) {
+        ObjectId objectId;
+
+        try {
+            objectId = new ObjectId(userId);
+        } catch (Exception e) {
+            return Response
+                    .status(Response.Status.NOT_FOUND)
+                    .entity(new Document("error", "Invalid object id!").toJson())
+                    .build();
+        }
+        Response res = retrieveUser(userId, false);
+        String entity = res.readEntity(String.class);
+        Document updatedAccountDocument = Document.parse(entity);
+        updatedAccountDocument.getList("MyQuotes",String.class).add(quoteId);
+        UpdateResult updateResult = accountCollection.updateOne(
+                eq("_id", objectId),
+                new Document("$set", updatedAccountDocument)
+        );
+
+        if (updateResult.getModifiedCount() == 1) {
+            try {
+                ArrayList<String> fieldsList = new ArrayList<String>(
+                        List.of("Email", "Username", "admin", "Notifications", "MyQuotes",
+                                "BookmarkedQuotes", "SharedQuotes", "MyTags", "Profession", "PersonalQuote","UsedQuotes"));
+
+                Bson projectionFields = Projections.fields(
+                        Projections.include(fieldsList));
+
+                return Response
+                        .status(Response.Status.OK)
+                        .entity(accountCollection.find(eq("_id", objectId)).projection(projectionFields).first().toJson())
+                        .build();
+            } catch (NullPointerException e) {
+                return Response
+                        .status(Response.Status.NOT_FOUND)
+                        .entity(new Document("error", "Account Not found!").toJson())
+                        .build();
+            }
+        } else {
+            return Response
+                    .status(Response.Status.NOT_FOUND)
+                    .entity(new Document("error", "Account Not found!").toJson())
+                    .build();
+        }
+    }
 }

--- a/_backend/services/user-service/src/main/java/com/accounts/BookmarkResource.java
+++ b/_backend/services/user-service/src/main/java/com/accounts/BookmarkResource.java
@@ -48,7 +48,6 @@ public class BookmarkResource {
     @PathParam("quoteId") String quoteId,
     @Context HttpHeaders headers) {
 
-        String json = null;
         String authHeader = headers.getHeaderString(HttpHeaders.AUTHORIZATION);
 
         if (authHeader == null || !authHeader.toLowerCase().startsWith("bearer ")) {
@@ -70,7 +69,7 @@ public class BookmarkResource {
             }
             String userId = accountService.getAccountIdByEmail(acc.Email);
             acc.BookmarkedQuotes.add(quoteId);
-            json = acc.toJson();
+            String json = acc.toJson();
             Response quoteSearchRes;
             try{
                 quoteSearchRes = quoteClient.idSearch(quoteId);
@@ -102,13 +101,10 @@ public class BookmarkResource {
                 }
              
             }
-           
-            int currentBookmarks = quoteSearchDoc.getInteger("bookmarks", 0);
-            quoteSearchDoc.put("bookmarks", currentBookmarks + 1);
-            quoteSearchDoc.remove("creator");
-            Response quoteUpdateRes = quoteClient.updateQuote(quoteSearchDoc.toJson());
-            if(quoteUpdateRes.getStatus()!=Response.Status.OK.getStatusCode()){
-            return quoteUpdateRes;
+            
+            Response quoteBookmarkRes = quoteClient.bookmarkQuote(quoteId,authHeader);
+            if(quoteBookmarkRes.getStatus()!=Response.Status.OK.getStatusCode()){
+            return quoteBookmarkRes;
          }
         }
         else{
@@ -393,12 +389,7 @@ public class BookmarkResource {
             if(quoteSearchRes.getStatus()!=Response.Status.OK.getStatusCode()){
                 return quoteSearchRes;
                 }
-            String quoteSearchString = quoteSearchRes.readEntity(String.class);
-            Document quoteSearchDoc = Document.parse(quoteSearchString);
-            quoteSearchDoc.remove("creator");
-            int currentBookmarks = quoteSearchDoc.getInteger("bookmarks", 0);
-            quoteSearchDoc.put("bookmarks", currentBookmarks - 1);
-            Response quoteUpdateRes = quoteClient.updateQuote(quoteSearchDoc.toJson());
+            Response quoteUpdateRes = quoteClient.deleteBookmark(quoteId,authHeader);
             if(quoteUpdateRes.getStatus()!=Response.Status.OK.getStatusCode()){
             return Response
             .status(Response.Status.BAD_GATEWAY)

--- a/_backend/services/user-service/src/main/java/com/accounts/QuoteClient.java
+++ b/_backend/services/user-service/src/main/java/com/accounts/QuoteClient.java
@@ -9,9 +9,14 @@ import jakarta.ws.rs.core.Response;
 public interface QuoteClient{
    
     @PUT
-    @Path("/quotes/update/bookmark")
-    @Consumes(MediaType.APPLICATION_JSON)
-    Response updateQuote(String rawJson);
+    @Path("/quotes/bookmark/increment/{quoteID}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response bookmarkQuote(@PathParam("quoteID") String quoteID, @HeaderParam("Authorization") String authHeader);
+
+    @DELETE
+    @Path("/quotes/bookmark/decrement/{quoteID}")
+    @Produces(MediaType.APPLICATION_JSON)
+    Response deleteBookmark(@PathParam("quoteID") String quoteID, @HeaderParam("Authorization") String authHeader);
 
     @GET
     @Path("/quotes/search/id/{quoteID}")


### PR DESCRIPTION
This makes the calls between the service to the hidden update endpoints less dangerous. We've never worked out a good way for the services to talk to eachother and if quote service had to update a user or vice versa they both relied on an unprotected duplicate update endpoint. This does not provide an actual secure way for the services to talk to one another but previously both QuoteClient and UserClient relied on these unprotected update endpoints that were identical to general update just with no jwt check  and a request body that allowed updated of everything from creator, author, username, etc. These endpoints have been replaced with purpose specific ones that only update the field in question and are now protected with JWT's. Instead of a hidden endpoint that takes a request body, both now only take an id and that id is searched with and only the relevant field is updated(incrementing bookmark count from user service or inserting/deleting from MyQuotes in quote service. 